### PR TITLE
Allowing SSM parameter values to have short keys

### DIFF
--- a/terraform/aws/utils/parameter-store/README.md
+++ b/terraform/aws/utils/parameter-store/README.md
@@ -8,7 +8,7 @@ This example creates a new `String` parameter called `/cp/prod/app/database/mast
 
 ```hcl
 module "store_write" {
-  source          = "./utils/parameter-store"
+  source          = "./terraform/aws/utils/parameter-store"
 
   parameter_write = [
     {
@@ -30,7 +30,44 @@ This example reads a value from the parameter store with the name `/cp/prod/app/
 
 ```hcl
 module "store_read" {
-  source         = "./utils/parameter-store"
+  source         = "./terraform/aws/utils/parameter-store"
   parameter_read = ["/cp/prod/app/database/master_password"]
+}
+```
+
+This example reads a value from the parameter store with the name `/cp/prod/app/security/security_group_id` and `/cp/dev/app/security/security_group_id` and outputs `map_decoded_bn` with the parameter_read_map value as the key instead of the parameter path. Allows a short hand key name to reference parameter value instead of full parameter path.
+
+```hcl
+locals {
+  ssm_state_read_enable = true
+  ssm_read_parameters = {
+    "/cp/prod/app/security/security_group_id" = "prod_security_group_id"
+    "/cp/dev/app/security/security_group_id"  = "dev_security_group_id"
+  }
+  store_read          = local.ssm_state_read_enable && length(keys(try(module.store_read.map_decoded_bn, {}))) > 0 ? module.store_read.map_decoded_bn : {}
+}
+
+module "store_read" {
+  source         = "./terraform/aws/utils/parameter-store"
+  enabled        = local.ssm_state_read_enable
+  parameter_read_map = local.ssm_read_parameters
+}
+
+resource "aws_security_group_rule" "dev_sg_http" {
+  from_port                = 80
+  protocol                 = "tcp"
+  security_group_id        = local.store_read.dev_security_group_id
+  source_security_group_id = sg-654321
+  to_port                  = 8080
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "prod_sg_http" {
+  from_port                = 80
+  protocol                 = "tcp"
+  security_group_id        = local.store_read.prod_security_group_id
+  source_security_group_id = sg-123456
+  to_port                  = 8080
+  type                     = "ingress"
 }
 ```

--- a/terraform/aws/utils/parameter-store/main.tf
+++ b/terraform/aws/utils/parameter-store/main.tf
@@ -1,10 +1,11 @@
 locals {
-  parameter_write = var.enabled ? { for e in var.parameter_write : e.name => merge(var.parameter_write_defaults, e) } : {}
+  parameter_write    = var.enabled ? { for e in var.parameter_write : e.name => merge(var.parameter_write_defaults, e) } : {}
+  parameter_read_map = var.enabled ? (length(var.parameter_read) > 0 ? { for p in var.parameter_read : p => p } : var.parameter_read_map) : {}
 }
 
 data "aws_ssm_parameter" "read" {
-  count = var.enabled ? length(var.parameter_read) : 0
-  name  = element(var.parameter_read, count.index)
+  count = var.enabled ? length(local.parameter_read_map) : 0
+  name  = element(keys(local.parameter_read_map), count.index)
 }
 
 resource "aws_ssm_parameter" "default" {

--- a/terraform/aws/utils/parameter-store/outputs.tf
+++ b/terraform/aws/utils/parameter-store/outputs.tf
@@ -38,7 +38,7 @@ locals {
       )
     )
   )
-  basename_decoded_values = { for k, v in zipmap(local.name_list, local.value_list) : (try(basename(k), k)) => (try(jsondecode(v), tostring(v == var.empty_string_sub ? "" : v))) }
+  basename_decoded_values = { for k, v in zipmap(local.name_list, local.value_list) : lookup(local.parameter_read_map, k, "") => (try(jsondecode(v), tostring(v == var.empty_string_sub ? "" : v))) }
 }
 
 output "names" {
@@ -52,7 +52,11 @@ output "values" {
 }
 
 output "map_decoded_bn" {
-  description = "A map of the names and values created"
+  description = <<-EOT
+  A map of the names and values created.
+  Defaults to full parameter path for key and value if `parameter_read` list is provided.
+  Uses `parameter_read_map` values as the keys to SSM parameter values if `parameter_read` is not set.
+  EOT
   value       = local.basename_decoded_values
 }
 

--- a/terraform/aws/utils/parameter-store/variables.tf
+++ b/terraform/aws/utils/parameter-store/variables.tf
@@ -11,8 +11,27 @@ variable "tags" {
 
 variable "parameter_read" {
   type        = list(string)
-  description = "List of parameters to read from SSM. These must already exist otherwise an error is returned. Can be used with `parameter_write` as long as the parameters are different."
+  description = <<-EOT
+  List of parameters to read from SSM.
+  These must already exist otherwise an error is returned.
+  Can be used with `parameter_write` as long as the parameters are different.
+  `parameter_read` is used if set and `parameter_read_map` ignored. Only use one or the other.
+  EOT
   default     = []
+}
+
+variable "parameter_read_map" {
+  type        = map(any)
+  description = <<-EOT
+  Map of parameters to read from SSM.
+  SSM Parameters as keys and shorthand name as values.
+  shorthand names will be used as the key in `map_decoded_bn` output for the SSM Parameter Values.
+  SSM Parameters must already exist otherwise an error is occurs.
+  Can be used with `parameter_write` as long as the parameters are different.
+  `parameter_read_map` is ignored if `parameter_read` is set. Only use one or the other.
+  Duplicate values in map are not permited since they will be used as key names in `map_decoded_bn`
+  EOT
+  default     = {}
 }
 
 variable "parameter_write" {


### PR DESCRIPTION
* Added `parameter_read_map` variable that can be provided as a map with the SSM parameter as the key and the short hand key as the value.
* Updated `basename_decoded_values` to create a map with the full parameter path as the key and value if `parameter_read_map` is not provided.
* Changed data source `aws_ssm_parameter.read` to instead use a local so that a map is always used.
* Updated the README.md to have an example of using both.
* Updated the descriptions of outputs and variables to be more complete.