### PR TITLE
Only return read_map decoded if present

### DIFF
--- a/terraform/aws/utils/parameter-store/outputs.tf
+++ b/terraform/aws/utils/parameter-store/outputs.tf
@@ -38,7 +38,7 @@ locals {
       )
     )
   )
-  basename_decoded_values = { for k, v in zipmap(local.name_list, local.value_list) : lookup(local.parameter_read_map, k, "") => (try(jsondecode(v), tostring(v == var.empty_string_sub ? "" : v))) }
+  basename_decoded_values = { for k, v in zipmap(local.name_list, local.value_list) : (length(local.parameter_read_map) > 0 ? lookup(local.parameter_read_map, k, "") : k) => (try(jsondecode(v), tostring(v == var.empty_string_sub ? "" : v))) }
 }
 
 output "names" {


### PR DESCRIPTION
* Check whether the local.parameter_read_map has a map of values present before decoding the SSM parameters. This is only useful when reading SSM parameters from storage not when writing them. Will cause an error otherwise due to duplicate empty keys in `lookup(local.parameter_read_map, k, "")` return.